### PR TITLE
Add CPU/GPU configuration profiles and PyCharm run configs (fixes #31)Add CPU and GPU config profiles + run configs + README update (fixes …

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,33 @@ pip install piper-tts
 ```bash
 python setup/argossetup.py
 ```
+Configuration Profiles
 
+LLT now includes multiple configuration profiles stored in the config/ directory.
+Each profile adjusts device usage and model settings to support different hardware environments.
+
+default.yaml – General-purpose settings for most systems.
+
+cpu_safe.yaml – Forces CPU-only mode with lighter ASR settings.
+
+gpu_fast.yaml – Enables GPU acceleration with higher-quality ASR settings.
+
+To run the pipeline with a specific profile:
+
+python -m app.pipeline --profile config/default.yaml
+python -m app.pipeline --profile config/cpu_safe.yaml
+python -m app.pipeline --profile config/gpu_fast.yaml
+
+
+In PyCharm, three Run Configurations are included:
+
+Run Pipeline – Default
+
+Run Pipeline – CPU Safe
+
+Run Pipeline – GPU Fast
+
+These can be selected from the Run Configuration dropdown in the top-right corner of PyCharm.
 ## 🔮 Future Work
 - 🎧 Integrate real-time microphone input and output
 - 🔄 Enable two-way speech conversation simulation

--- a/config/cpu_safe.yaml
+++ b/config/cpu_safe.yaml
@@ -1,0 +1,26 @@
+audio:
+  sample_rate: 16000
+  block_seconds: 0.5
+  device_input_index: null
+
+vad:
+  use_webrtc: false
+  energy_gate: 0.0005
+  pause_timeout: 0.8
+
+asr:
+  model_size: "small"
+  device: "cpu"
+  language: "en"
+  beam_size: 2
+  temperature: 0.0
+  min_conf: 0.7
+
+translate:
+  from_lang: "en"
+  to_lang: "es"
+
+tts:
+  enabled: true
+  voice_path: "models/piper/en_US-lessac-medium.onnx"
+  voice_config: "models/piper/en_US-lessac-medium.onnx.json"

--- a/config/gpu_fast.yaml
+++ b/config/gpu_fast.yaml
@@ -1,0 +1,26 @@
+audio:
+  sample_rate: 16000
+  block_seconds: 0.5
+  device_input_index: null
+
+vad:
+  use_webrtc: false
+  energy_gate: 0.0005
+  pause_timeout: 0.8
+
+asr:
+  model_size: "small"
+  device: "cuda"
+  language: "en"
+  beam_size: 8
+  temperature: 0.0
+  min_conf: 0.7
+
+translate:
+  from_lang: "en"
+  to_lang: "es"
+
+tts:
+  enabled: true
+  voice_path: "models/piper/en_US-lessac-medium.onnx"
+  voice_config: "models/piper/en_US-lessac-medium.onnx.json"


### PR DESCRIPTION
…#31)This PR adds support for multiple configuration profiles and matching run configurations.

Changes include:
- Added `config/cpu_safe.yaml` (CPU-only, reduced ASR beam size)
- Added `config/gpu_fast.yaml` (CUDA/GPU-enabled, increased ASR beam size)
- Added run configurations for:
  - Run Pipeline – Default
  - Run Pipeline – CPU Safe
  - Run Pipeline – GPU Fast
- Updated README with new "Configuration Profiles" section

This completes backlog issue #31.